### PR TITLE
added support for send email from the email pack

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Build Client Packages
 on:
   release:
-    types: [ "published" ]
+    types: ['published']
 
 jobs:
   build:
@@ -9,12 +9,12 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-        
+
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '2.2.103'
-          
+
       - name: Get Latest Release
         id: get_release
         uses: bruceadams/get-release@v1.2.1
@@ -29,7 +29,7 @@ jobs:
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           fi
-          echo ::set-env name=release_version::$VERSION
+          echo "release_version=$VERSION" >> $GITHUB_ENV
 
       - name: Build Stackstorm.Api.Client
         run: |
@@ -37,8 +37,8 @@ jobs:
           /p:version=${{ env.release_version }}                                   \
           /p:authors="Carnegie Mellon University/Software Engineering Institute"  \
           /p:owners="Carnegie Mellon University/Software Engineering Institute"   \
-          /p:description="Stackstorm.Api.Client"   
-          
+          /p:description="Stackstorm.Api.Client"
+
           cd Stackstorm.Api.Client/artifacts
           mv Stackstorm.Api.Client.${{ env.release_version }}.nupkg Stackstorm.Api.Client.${{ env.release_version }}.nupkg.bak
           unzip Stackstorm.Api.Client.${{ env.release_version }}.nupkg.bak -d tmp
@@ -49,15 +49,15 @@ jobs:
           sed -i '/<\/version>/a \    <projectUrl>https:\/\/github.com\/cmu-sei\/crucible<\/projectUrl>' Stackstorm.Api.Client.nuspec
           sed -i '/<\/version>/a \    <repository type="git" url="https:\/\/github.com\/cmu-sei\/crucible.git" \/>' Stackstorm.Api.Client.nuspec
           zip -r ../Stackstorm.Api.Client.${{ env.release_version }}.nupkg *
-          
+
       - name: Build Stackstorm.Connector
         run: |
           dotnet build -c Release Stackstorm.Connector                            \
           /p:version=${{ env.release_version }}                                   \
           /p:authors="Carnegie Mellon University/Software Engineering Institute"  \
           /p:owners="Carnegie Mellon University/Software Engineering Institute"   \
-          /p:description="Stackstorm.Connector"   
-          
+          /p:description="Stackstorm.Connector"
+
           cd Stackstorm.Connector/artifacts
           mv Stackstorm.Connector.${{ env.release_version }}.nupkg Stackstorm.Connector.${{ env.release_version }}.nupkg.bak
           unzip Stackstorm.Connector.${{ env.release_version }}.nupkg.bak -d tmp
@@ -68,16 +68,16 @@ jobs:
           sed -i '/<\/version>/a \    <projectUrl>https:\/\/github.com\/cmu-sei\/crucible<\/projectUrl>' Stackstorm.Connector.nuspec
           sed -i '/<\/version>/a \    <repository type="git" url="https:\/\/github.com\/cmu-sei\/crucible.git" \/>' Stackstorm.Connector.nuspec
           zip -r ../Stackstorm.Connector.${{ env.release_version }}.nupkg *
-                
+
       - name: Publish to Nuget.org as Unlisted
         run: |
           dotnet nuget push Stackstorm.Connector/artifacts/Stackstorm.Connector.${{ env.release_version }}.nupkg -k ${{ secrets.NUGET_APIKEY }} -s https://api.nuget.org/v3/index.json
           dotnet nuget delete Stackstorm.Connector ${{ env.release_version }} --non-interactive -k ${{ secrets.NUGET_APIKEY_UNLIST }} -s https://api.nuget.org/v3/index.json
           dotnet nuget push Stackstorm.Api.Client/artifacts/Stackstorm.Api.Client.${{ env.release_version }}.nupkg -k ${{ secrets.NUGET_APIKEY }} -s https://api.nuget.org/v3/index.json
           dotnet nuget delete Stackstorm.Api.Client ${{ env.release_version }} --non-interactive -k ${{ secrets.NUGET_APIKEY_UNLIST }} -s https://api.nuget.org/v3/index.json
-      
+
       - name: Upload Release Asset
-        id: upload-release-asset 
+        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '2.2.103'
+          dotnet-version: '3.1.x'
 
       - name: Get Latest Release
         id: get_release

--- a/Stackstorm.Api.Client.Test/Vsphere.cs
+++ b/Stackstorm.Api.Client.Test/Vsphere.cs
@@ -26,7 +26,7 @@ namespace Stackstorm.Api.Client.Test
         public async void GetVmsReturnsArrayOfVms()
         {
             var cluster = "[\"domain-c9\"]";
-            var executionResult = await this.Client.VSphere.GetVms(new Dictionary<string, string> {{"clusters", cluster}});
+            var executionResult = await this.Client.VSphere.GetVms(new Dictionary<string, object> { { "clusters", cluster } });
             var j = JObject.Parse(executionResult.result.ToString());
 
             var hasVms = false;
@@ -48,8 +48,8 @@ namespace Stackstorm.Api.Client.Test
         public async void GetVmDetailReturnsUuid()
         {
             var vmId = "[\"vm-303\"]"; //this is a moid
-            
-            var executionResult = await this.Client.VSphere.VmGetDetail(new Dictionary<string, string> {{"vm_ids", vmId}});
+
+            var executionResult = await this.Client.VSphere.VmGetDetail(new Dictionary<string, object> { { "vm_ids", vmId } });
             var tokens = executionResult.result.ToString().ToJTokens();
             foreach (var token in tokens)
             {
@@ -63,8 +63,8 @@ namespace Stackstorm.Api.Client.Test
         public async void GetGuestInfoReturns()
         {
             var vmId = "[\"vm-303\"]"; //this is a moid
-            
-            var executionResult = await this.Client.VSphere.VmGetGuestInfo(new Dictionary<string, string> {{"vm_ids", vmId}});
+
+            var executionResult = await this.Client.VSphere.VmGetGuestInfo(new Dictionary<string, object> { { "vm_ids", vmId } });
             var tokens = executionResult.result.ToString().ToJTokens();
 
             foreach (var token in tokens)
@@ -79,9 +79,9 @@ namespace Stackstorm.Api.Client.Test
         public async void GetMoidReturnsMoid()
         {
             var vmName = "[\"Win10.10\"]";
-            var executionResult = await this.Client.VSphere.GetMoid(new Dictionary<string, string> {{"object_names", vmName}, {"object_type", "VirtualMachine"}});
-            var j = ((JToken) executionResult.result)["result"];
-            
+            var executionResult = await this.Client.VSphere.GetMoid(new Dictionary<string, object> { { "object_names", vmName }, { "object_type", "VirtualMachine" } });
+            var j = ((JToken)executionResult.result)["result"];
+
             foreach (var prop in j.OfType<JProperty>())
             {
                 Assert.True(!string.IsNullOrEmpty(prop.Value.ToString()));
@@ -93,9 +93,9 @@ namespace Stackstorm.Api.Client.Test
         public async void VmGetMoidReturnsMoid()
         {
             var vmName = "[\"Win10.10\"]";
-            var executionResult = await this.Client.VSphere.VmGetMoid(new Dictionary<string, string> {{"vm_names", vmName}});
-            var j = ((JToken) executionResult.result)["result"];
-            
+            var executionResult = await this.Client.VSphere.VmGetMoid(new Dictionary<string, object> { { "vm_names", vmName } });
+            var j = ((JToken)executionResult.result)["result"];
+
             foreach (var prop in j.OfType<JProperty>())
             {
                 Assert.True(!string.IsNullOrEmpty(prop.Value.ToString()));
@@ -106,8 +106,8 @@ namespace Stackstorm.Api.Client.Test
         [Fact]
         public async void GuestFileRead()
         {
-            var executionResult = await this.Client.VSphere.GuestFileRead(new Dictionary<string, string> {{"vm_id", "vm-302"}, {"username", "Developer"}, {"password", "develop@1"}, {"guest_file", @"C:\Users\Developer\testGet.txt"}});
-            var fileTextObject = ((JObject) executionResult.result)["result"];
+            var executionResult = await this.Client.VSphere.GuestFileRead(new Dictionary<string, object> { { "vm_id", "vm-302" }, { "username", "Developer" }, { "password", "develop@1" }, { "guest_file", @"C:\Users\Developer\testGet.txt" } });
+            var fileTextObject = ((JObject)executionResult.result)["result"];
 
             Assert.NotNull(fileTextObject);
             Assert.True(!string.IsNullOrEmpty(fileTextObject.ToString()));
@@ -116,14 +116,14 @@ namespace Stackstorm.Api.Client.Test
         [Fact]
         public async void VmTurnOn()
         {
-            var executionResult = await this.Client.VSphere.VmPowerOn(new Dictionary<string, string> {{"vm_id", "vm-303"}});
+            var executionResult = await this.Client.VSphere.VmPowerOn(new Dictionary<string, object> { { "vm_id", "vm-303" } });
             Assert.NotNull(executionResult);
         }
-        
+
         [Fact]
         public async void VmTurnOff()
         {
-            var executionResult = await this.Client.VSphere.VmPowerOff(new Dictionary<string, string> {{"vm_id", "vm-303"}});
+            var executionResult = await this.Client.VSphere.VmPowerOff(new Dictionary<string, object> { { "vm_id", "vm-303" } });
             Assert.NotNull(executionResult);
         }
 

--- a/Stackstorm.Api.Client/Apis/ExecutionsApi.cs
+++ b/Stackstorm.Api.Client/Apis/ExecutionsApi.cs
@@ -57,21 +57,6 @@ namespace Stackstorm.Api.Client.Apis
         /// <param name="actionName">Name of the action. </param>
         /// <param name="parameters">The parameters for the given action. </param>
         /// <returns>The resulting execution; </returns>
-        /// <seealso cref="M:Stackstorm.Api.Client.Apis.IExecutionsApi.ExecuteActionAsync(string,Dictionary{string,string})"/>
-        public async Task<Execution> ExecuteActionAsync(string actionName, Dictionary<string, string> parameters)
-        {
-            ExecuteActionRequest request = new ExecuteActionRequest
-            {
-                action = actionName,
-                parameters = parameters
-            };
-            return await _host.PostApiRequestAsync<Execution, ExecuteActionRequest>("/v1/executions/", request);
-        }
-
-        /// <summary>Executes the action. </summary>
-        /// <param name="actionName">Name of the action. </param>
-        /// <param name="parameters">The parameters for the given action. </param>
-        /// <returns>The resulting execution; </returns>
         /// <seealso cref="M:Stackstorm.Api.Client.Apis.IExecutionsApi.ExecuteActionAsync(string,Dictionary{string,object})"/>
         public async Task<Execution> ExecuteActionAsync(string actionName, Dictionary<string, object> parameters)
         {

--- a/Stackstorm.Api.Client/Apis/IExecutionsApi.cs
+++ b/Stackstorm.Api.Client/Apis/IExecutionsApi.cs
@@ -29,12 +29,6 @@ namespace Stackstorm.Api.Client.Apis
         /// <param name="actionName"> Name of the action. </param>
         /// <param name="parameters"> The parameters for the given action. </param>
         /// <returns> The resulting execution; </returns>
-        Task<Execution> ExecuteActionAsync(string actionName, Dictionary<string, string> parameters);
-
-        /// <summary> Executes the action. </summary>
-        /// <param name="actionName"> Name of the action. </param>
-        /// <param name="parameters"> The parameters for the given action. </param>
-        /// <returns> The resulting execution; </returns>
         Task<Execution> ExecuteActionAsync(string actionName, Dictionary<string, object> parameters);
     }
 }

--- a/Stackstorm.Api.Client/Executions/Core.cs
+++ b/Stackstorm.Api.Client/Executions/Core.cs
@@ -9,22 +9,22 @@ namespace stackstorm.api.client.Executions
 {
     public interface ICore
     {
-        Task<Execution> Announcement(Dictionary<string, string> parameters);
-        Task<Execution> Ask(Dictionary<string, string> parameters);
-        Task<Execution> Echo(Dictionary<string, string> parameters);
-        Task<Execution> Http(Dictionary<string, string> parameters);
-        Task<Execution> InjectTrigger(Dictionary<string, string> parameters);
-        Task<Execution> SendLocalCommand(Dictionary<string, string> parameters);
-        Task<Execution> SendLocalSudo(Dictionary<string, string> parameters);
-        Task<Execution> Noop(Dictionary<string, string> parameters);
-        Task<Execution> Pause(Dictionary<string, string> parameters);
-        Task<Execution> SendLinuxRemoteCommand(Dictionary<string, string> parameters);
-        Task<Execution> SendLinuxRemoteSudo(Dictionary<string, string> parameters);
-        Task<Execution> SendEmail(Dictionary<string, string> parameters);
-        Task<Execution> Uuid(Dictionary<string, string> parameters);
-        Task<Execution> SendWindowsCommand(Dictionary<string, string> parameters);
-        Task<Execution> SendWinRmCommand(Dictionary<string, string> parameters);
-        Task<Execution> SendWinRmPowershell(Dictionary<string, string> parameters);
+        Task<Execution> Announcement(Dictionary<string, object> parameters);
+        Task<Execution> Ask(Dictionary<string, object> parameters);
+        Task<Execution> Echo(Dictionary<string, object> parameters);
+        Task<Execution> Http(Dictionary<string, object> parameters);
+        Task<Execution> InjectTrigger(Dictionary<string, object> parameters);
+        Task<Execution> SendLocalCommand(Dictionary<string, object> parameters);
+        Task<Execution> SendLocalSudo(Dictionary<string, object> parameters);
+        Task<Execution> Noop(Dictionary<string, object> parameters);
+        Task<Execution> Pause(Dictionary<string, object> parameters);
+        Task<Execution> SendLinuxRemoteCommand(Dictionary<string, object> parameters);
+        Task<Execution> SendLinuxRemoteSudo(Dictionary<string, object> parameters);
+        Task<Execution> SendEmail(Dictionary<string, object> parameters);
+        Task<Execution> Uuid(Dictionary<string, object> parameters);
+        Task<Execution> SendWindowsCommand(Dictionary<string, object> parameters);
+        Task<Execution> SendWinRmCommand(Dictionary<string, object> parameters);
+        Task<Execution> SendWinRmPowershell(Dictionary<string, object> parameters);
     }
 
     public class Core : ExecutionsBase, ICore
@@ -36,7 +36,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Action that broadcasts the announcement to all stream consumers
         /// </summary>
-        public async Task<Execution> Announcement(Dictionary<string, string> parameters)
+        public async Task<Execution> Announcement(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.announcement", parameters);
         }
@@ -44,7 +44,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Action for initiating an Inquiry (usually in a workflow)
         /// </summary>
-        public async Task<Execution> Ask(Dictionary<string, string> parameters)
+        public async Task<Execution> Ask(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.ask", parameters);
         }
@@ -52,23 +52,23 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Action that executes the Linux echo command on the localhost
         /// </summary>
-        public async Task<Execution> Echo(Dictionary<string, string> parameters)
+        public async Task<Execution> Echo(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.echo", parameters);
         }
 
         /// <summary>
-        /// Action that performs an http request    
+        /// Action that performs an http request
         /// </summary>
-        public async Task<Execution> Http(Dictionary<string, string> parameters)
+        public async Task<Execution> Http(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.http", parameters);
         }
 
         /// <summary>
-        /// Action which injects a new trigger in the system    
+        /// Action which injects a new trigger in the system
         /// </summary>
-        public async Task<Execution> InjectTrigger(Dictionary<string, string> parameters)
+        public async Task<Execution> InjectTrigger(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.inject_trigger", parameters);
         }
@@ -76,23 +76,23 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Action that executes an arbitrary Linux command on the localhost
         /// </summary>
-        public async Task<Execution> SendLocalCommand(Dictionary<string, string> parameters)
+        public async Task<Execution> SendLocalCommand(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.local", parameters);
         }
 
         /// <summary>
-        /// Action that executes an arbitrary Linux command on the localhost    
+        /// Action that executes an arbitrary Linux command on the localhost
         /// </summary>
-        public async Task<Execution> SendLocalSudo(Dictionary<string, string> parameters)
+        public async Task<Execution> SendLocalSudo(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.local_sudo", parameters);
         }
 
         /// <summary>
-        /// Action that does nothing    
+        /// Action that does nothing
         /// </summary>
-        public async Task<Execution> Noop(Dictionary<string, string> parameters)
+        public async Task<Execution> Noop(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.noop", parameters);
         }
@@ -100,7 +100,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Action to pause current thread of workflow/sub-workflow
         /// </summary>
-        public async Task<Execution> Pause(Dictionary<string, string> parameters)
+        public async Task<Execution> Pause(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.pause", parameters);
         }
@@ -108,7 +108,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Action to execute arbitrary linux command remotely
         /// </summary>
-        public async Task<Execution> SendLinuxRemoteCommand(Dictionary<string, string> parameters)
+        public async Task<Execution> SendLinuxRemoteCommand(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.remote", parameters);
         }
@@ -116,15 +116,15 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Action to execute arbitrary linux command remotely
         /// </summary>
-        public async Task<Execution> SendLinuxRemoteSudo(Dictionary<string, string> parameters)
+        public async Task<Execution> SendLinuxRemoteSudo(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.remote_sudo", parameters);
         }
 
         /// <summary>
-        /// This sends an email    
+        /// This sends an email
         /// </summary>
-        public async Task<Execution> SendEmail(Dictionary<string, string> parameters)
+        public async Task<Execution> SendEmail(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.sendmail", parameters);
         }
@@ -132,7 +132,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Generate a new UUID (default uuid4)
         /// </summary>
-        public async Task<Execution> Uuid(Dictionary<string, string> parameters)
+        public async Task<Execution> Uuid(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.uuid", parameters);
         }
@@ -140,7 +140,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Action to execute arbitrary Windows command remotely
         /// </summary>
-        public async Task<Execution> SendWindowsCommand(Dictionary<string, string> parameters)
+        public async Task<Execution> SendWindowsCommand(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.windows_cmd", parameters);
         }
@@ -148,7 +148,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Action to execute arbitrary Windows Command Prompt command remotely via WinRM
         /// </summary>
-        public async Task<Execution> SendWinRmCommand(Dictionary<string, string> parameters)
+        public async Task<Execution> SendWinRmCommand(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.winrm_cmd", parameters);
         }
@@ -156,7 +156,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Action to execute arbitrary Windows PowerShell command remotely via WinRM.
         /// </summary>
-        public async Task<Execution> SendWinRmPowershell(Dictionary<string, string> parameters)
+        public async Task<Execution> SendWinRmPowershell(Dictionary<string, object> parameters)
         {
             return await AddExecution("core.winrm_ps_cmd", parameters);
         }

--- a/Stackstorm.Api.Client/Executions/Email.cs
+++ b/Stackstorm.Api.Client/Executions/Email.cs
@@ -1,0 +1,29 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Stackstorm.Api.Client;
+using Stackstorm.Api.Client.Models;
+
+namespace stackstorm.api.client.Executions
+{
+    public interface IEmail
+    {
+        Task<Execution> SendEmail(Dictionary<string, object> parameters);
+    }
+    public class Email : ExecutionsBase, IEmail
+    {
+        public Email(ISt2Client host) : base(host)
+        {
+        }
+
+        /// <summary>
+        /// Sends an email
+        /// </summary>
+        public async Task<Execution> SendEmail(Dictionary<string, object> parameters)
+        {
+            return await AddExecution("email.send_email", parameters);
+        }
+    }
+}

--- a/Stackstorm.Api.Client/Executions/ExecutionsBase.cs
+++ b/Stackstorm.Api.Client/Executions/ExecutionsBase.cs
@@ -14,13 +14,13 @@ namespace stackstorm.api.client.Executions
     {
         private ISt2Client _host;
         private static readonly Logger _log = LogManager.GetCurrentClassLogger();
-        
+
         protected ExecutionsBase(ISt2Client host)
         {
             _host = host ?? throw new ArgumentNullException(nameof(host));
         }
-        
-        internal async Task<Execution> AddExecution(string action, Dictionary<string, string> parameters)
+
+        internal async Task<Execution> AddExecution(string action, Dictionary<string, object> parameters)
         {
             if (!_host.HasToken())
             {
@@ -28,20 +28,7 @@ namespace stackstorm.api.client.Executions
             }
             try
             {
-                var tempParameters = new Dictionary<string, string>();
-                //delete any empty parameters
-                if (parameters != null)
-                {
-                    foreach (var p in parameters)
-                        if (!string.IsNullOrEmpty(p.Value))
-                            tempParameters.Add(p.Key, p.Value);
-                }
-
-                var executionRequest = new ExecutionRequest(action, tempParameters);
-                
-                //var requestString = Newtonsoft.Json.JsonConvert.SerializeObject(executionRequest);
-                //Console.WriteLine(requestString);
-
+                var executionRequest = new ExecutionRequest(action, parameters);
                 var r = await _host.PostApiRequestAsync<Execution, ExecutionRequest>("v1/executions", executionRequest);
                 return await Resolve(r);
             }

--- a/Stackstorm.Api.Client/Executions/VSphere.cs
+++ b/Stackstorm.Api.Client/Executions/VSphere.cs
@@ -10,45 +10,45 @@ namespace stackstorm.api.client.Executions
 {
     public interface IVSphere
     {
-        Task<Execution> GetMoid(Dictionary<string, string> parameters);
-        Task<Execution> GetVmConsoleUrls(Dictionary<string, string> parameters);
-        Task<Execution> GetVms(Dictionary<string, string> parameters);
-        Task<Execution> GetVmsWithUuid(Dictionary<string, string> parameters);
-        Task<Execution> GuestDirectoryCreate(Dictionary<string, string> parameters);
-        Task<Execution> GuestDirectoryDelete(Dictionary<string, string> parameters);
-        Task<Execution> GuestFileCreate(Dictionary<string, string> parameters);
-        Task<Execution> GuestFileDelete(Dictionary<string, string> parameters);
-        Task<Execution> GuestFileRead(Dictionary<string, string> parameters);
-        Task<Execution> GuestFileUpload(Dictionary<string, string> parameters);
-        Task<Execution> GuestFileUploadContent(Dictionary<string, string> parameters);
-        Task<Execution> GuestProcessRun(Dictionary<string, string> parameters);
-        Task<Execution> GuestProcessRunFast(Dictionary<string, string> parameters);
-        Task<Execution> GuestProcessStart(Dictionary<string, string> parameters);
-        Task<Execution> GuestProcessWait(Dictionary<string, string> parameters);
-        Task<Execution> GuestScriptRun(Dictionary<string, string> parameters);
-        Task<Execution> Hello(Dictionary<string, string> parameters);
-        Task<Execution> HostGet(Dictionary<string, string> parameters);
-        Task<Execution> HostGetNetworkHits(Dictionary<string, string> parameters);
-        Task<Execution> SetVm(Dictionary<string, string> parameters);
-        Task<Execution> CreateVmFromTemplate(Dictionary<string, string> parameters);
-        Task<Execution> VmGetEnvItems(Dictionary<string, string> parameters);
-        Task<Execution> VmGetGuestInfo(Dictionary<string, string> parameters);
-        Task<Execution> VmCreateBarebones(Dictionary<string, string> parameters);
-        Task<Execution> VmBuildBasic(Dictionary<string, string> parameters);
-        Task<Execution> VmEditMemory(Dictionary<string, string> parameters);
-        Task<Execution> VmGetDetail(Dictionary<string, string> parameters);
-        Task<Execution> VmAddHdd(Dictionary<string, string> parameters);
-        Task<Execution> VmGetMoid(Dictionary<string, string> parameters);
-        Task<Execution> VmNicAdd(Dictionary<string, string> parameters);
-        Task<Execution> VmNicEdit(Dictionary<string, string> parameters);
-        Task<Execution> VmPowerOff(Dictionary<string, string> parameters);
-        Task<Execution> VmPowerOn(Dictionary<string, string> parameters);
-        Task<Execution> VmRemove(Dictionary<string, string> parameters);
-        Task<Execution> VmScsiControllerAdd(Dictionary<string, string> parameters);
-        Task<Execution> VmGetUuid(Dictionary<string, string> parameters);
-        Task<Execution> VmGetRuntimeInfo(Dictionary<string, string> parameters);
-        Task<Execution> VmShutdown(Dictionary<string, string> parameters);
-        Task<Execution> Wait(Dictionary<string, string> parameters);
+        Task<Execution> GetMoid(Dictionary<string, object> parameters);
+        Task<Execution> GetVmConsoleUrls(Dictionary<string, object> parameters);
+        Task<Execution> GetVms(Dictionary<string, object> parameters);
+        Task<Execution> GetVmsWithUuid(Dictionary<string, object> parameters);
+        Task<Execution> GuestDirectoryCreate(Dictionary<string, object> parameters);
+        Task<Execution> GuestDirectoryDelete(Dictionary<string, object> parameters);
+        Task<Execution> GuestFileCreate(Dictionary<string, object> parameters);
+        Task<Execution> GuestFileDelete(Dictionary<string, object> parameters);
+        Task<Execution> GuestFileRead(Dictionary<string, object> parameters);
+        Task<Execution> GuestFileUpload(Dictionary<string, object> parameters);
+        Task<Execution> GuestFileUploadContent(Dictionary<string, object> parameters);
+        Task<Execution> GuestProcessRun(Dictionary<string, object> parameters);
+        Task<Execution> GuestProcessRunFast(Dictionary<string, object> parameters);
+        Task<Execution> GuestProcessStart(Dictionary<string, object> parameters);
+        Task<Execution> GuestProcessWait(Dictionary<string, object> parameters);
+        Task<Execution> GuestScriptRun(Dictionary<string, object> parameters);
+        Task<Execution> Hello(Dictionary<string, object> parameters);
+        Task<Execution> HostGet(Dictionary<string, object> parameters);
+        Task<Execution> HostGetNetworkHits(Dictionary<string, object> parameters);
+        Task<Execution> SetVm(Dictionary<string, object> parameters);
+        Task<Execution> CreateVmFromTemplate(Dictionary<string, object> parameters);
+        Task<Execution> VmGetEnvItems(Dictionary<string, object> parameters);
+        Task<Execution> VmGetGuestInfo(Dictionary<string, object> parameters);
+        Task<Execution> VmCreateBarebones(Dictionary<string, object> parameters);
+        Task<Execution> VmBuildBasic(Dictionary<string, object> parameters);
+        Task<Execution> VmEditMemory(Dictionary<string, object> parameters);
+        Task<Execution> VmGetDetail(Dictionary<string, object> parameters);
+        Task<Execution> VmAddHdd(Dictionary<string, object> parameters);
+        Task<Execution> VmGetMoid(Dictionary<string, object> parameters);
+        Task<Execution> VmNicAdd(Dictionary<string, object> parameters);
+        Task<Execution> VmNicEdit(Dictionary<string, object> parameters);
+        Task<Execution> VmPowerOff(Dictionary<string, object> parameters);
+        Task<Execution> VmPowerOn(Dictionary<string, object> parameters);
+        Task<Execution> VmRemove(Dictionary<string, object> parameters);
+        Task<Execution> VmScsiControllerAdd(Dictionary<string, object> parameters);
+        Task<Execution> VmGetUuid(Dictionary<string, object> parameters);
+        Task<Execution> VmGetRuntimeInfo(Dictionary<string, object> parameters);
+        Task<Execution> VmShutdown(Dictionary<string, object> parameters);
+        Task<Execution> Wait(Dictionary<string, object> parameters);
     }
     public class VSphere : ExecutionsBase, IVSphere
     {
@@ -59,7 +59,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Returns the MOID of vSphere managed entity corresponding to the specified parameters
         /// </summary>
-        public async Task<Execution> GetMoid(Dictionary<string, string> parameters)
+        public async Task<Execution> GetMoid(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.get_moid", parameters);
         }
@@ -67,7 +67,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Retrieves urls of the virtual machines' consoles
         /// </summary>
-        public async Task<Execution> GetVmConsoleUrls(Dictionary<string, string> parameters)
+        public async Task<Execution> GetVmConsoleUrls(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.get_vmconsole_urls", parameters);
         }
@@ -75,7 +75,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Retrieves the virtual machines on a vCenter Server system. It computes the union of Virtual Machine sets based on each parameter
         /// </summary>
-        public async Task<Execution> GetVms(Dictionary<string, string> parameters)
+        public async Task<Execution> GetVms(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.get_vms", parameters);
         }
@@ -83,7 +83,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Retrieves the virtual machines on a vCenter Server system with the UUID. It computes the union of Virtual Machine sets based on each parameter
         /// </summary>
-        public async Task<Execution> GetVmsWithUuid(Dictionary<string, string> parameters)
+        public async Task<Execution> GetVmsWithUuid(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.get_vms_with_uuid", parameters);
         }
@@ -91,7 +91,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Creates a temporary directory inside the guest
         /// </summary>
-        public async Task<Execution> GuestDirectoryCreate(Dictionary<string, string> parameters)
+        public async Task<Execution> GuestDirectoryCreate(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.guest_dir_create", parameters);
         }
@@ -99,7 +99,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Deletes a directory inside the guest
         /// </summary>
-        public async Task<Execution> GuestDirectoryDelete(Dictionary<string, string> parameters)
+        public async Task<Execution> GuestDirectoryDelete(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.guest_dir_delete", parameters);
         }
@@ -107,7 +107,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Creates a temporary file inside the guest
         /// </summary>
-        public async Task<Execution> GuestFileCreate(Dictionary<string, string> parameters)
+        public async Task<Execution> GuestFileCreate(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.guest_file_create", parameters);
         }
@@ -115,7 +115,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Deletes a file inside the guest
         /// </summary>
-        public async Task<Execution> GuestFileDelete(Dictionary<string, string> parameters)
+        public async Task<Execution> GuestFileDelete(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.guest_file_delete", parameters);
         }
@@ -123,7 +123,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Read a file inside the guest
         /// </summary>
-        public async Task<Execution> GuestFileRead(Dictionary<string, string> parameters)
+        public async Task<Execution> GuestFileRead(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.guest_file_read", parameters);
         }
@@ -131,7 +131,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Upload a file to the guest
         /// </summary>
-        public async Task<Execution> GuestFileUpload(Dictionary<string, string> parameters)
+        public async Task<Execution> GuestFileUpload(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.guest_file_upload", parameters);
         }
@@ -139,7 +139,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Upload a file to the guest with content
         /// </summary>
-        public async Task<Execution> GuestFileUploadContent(Dictionary<string, string> parameters)
+        public async Task<Execution> GuestFileUploadContent(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.guest_file_upload_content", parameters);
         }
@@ -147,7 +147,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Run a process inside the guest
         /// </summary>
-        public async Task<Execution> GuestProcessRun(Dictionary<string, string> parameters)
+        public async Task<Execution> GuestProcessRun(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.guest_process_run", parameters);
         }
@@ -155,7 +155,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Run a process inside the guest
         /// </summary>
-        public async Task<Execution> GuestProcessRunFast(Dictionary<string, string> parameters)
+        public async Task<Execution> GuestProcessRunFast(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.guest_process_run_fast", parameters);
         }
@@ -163,7 +163,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Start a process inside the guest
         /// </summary>
-        public async Task<Execution> GuestProcessStart(Dictionary<string, string> parameters)
+        public async Task<Execution> GuestProcessStart(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.guest_process_start", parameters);
         }
@@ -171,7 +171,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Wait for a process inside the guest to exit
         /// </summary>
-        public async Task<Execution> GuestProcessWait(Dictionary<string, string> parameters)
+        public async Task<Execution> GuestProcessWait(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.guest_process_wait", parameters);
         }
@@ -179,7 +179,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Run a script inside the guest
         /// </summary>
-        public async Task<Execution> GuestScriptRun(Dictionary<string, string> parameters)
+        public async Task<Execution> GuestScriptRun(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.guest_script_run", parameters);
         }
@@ -187,7 +187,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Wait for a Task to complete and returns its result
         /// </summary>
-        public async Task<Execution> Hello(Dictionary<string, string> parameters)
+        public async Task<Execution> Hello(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.hello_vsphere", parameters);
         }
@@ -195,7 +195,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Retrieve summary information for given Hosts (ESXi)
         /// </summary>
-        public async Task<Execution> HostGet(Dictionary<string, string> parameters)
+        public async Task<Execution> HostGet(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.host_get", parameters);
         }
@@ -203,7 +203,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Retrieve Network Hints for given Hosts (ESXi)
         /// </summary>
-        public async Task<Execution> HostGetNetworkHits(Dictionary<string, string> parameters)
+        public async Task<Execution> HostGetNetworkHits(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.host_network_hits_get", parameters);
         }
@@ -211,7 +211,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Changes configuration of a Virtual Machine
         /// </summary>
-        public async Task<Execution> SetVm(Dictionary<string, string> parameters)
+        public async Task<Execution> SetVm(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.set_vm", parameters);
         }
@@ -219,7 +219,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Create a new VM from existing template
         /// </summary>
-        public async Task<Execution> CreateVmFromTemplate(Dictionary<string, string> parameters)
+        public async Task<Execution> CreateVmFromTemplate(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_create_from_template", parameters);
         }
@@ -227,7 +227,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Retrieve list of Objects from VSphere
         /// </summary>
-        public async Task<Execution> VmGetEnvItems(Dictionary<string, string> parameters)
+        public async Task<Execution> VmGetEnvItems(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_env_items_get", parameters);
         }
@@ -235,7 +235,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Retrieve Guest details of a VM object
         /// </summary>
-        public async Task<Execution> VmGetGuestInfo(Dictionary<string, string> parameters)
+        public async Task<Execution> VmGetGuestInfo(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_guest_info_get", parameters);
         }
@@ -243,7 +243,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Create BareBones VM (CPU, Ram, Graphics Only)
         /// </summary>
-        public async Task<Execution> VmCreateBarebones(Dictionary<string, string> parameters)
+        public async Task<Execution> VmCreateBarebones(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_barebones_create", parameters);
         }
@@ -251,15 +251,15 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// WorkFlow to build a base VM hardware and optional power on (CPU, RAM, HDD, NIC)
         /// </summary>
-        public async Task<Execution> VmBuildBasic(Dictionary<string, string> parameters)
+        public async Task<Execution> VmBuildBasic(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_basic_build", parameters);
         }
 
         /// <summary>
-        /// Adjust CPU and RAM allocation for a Virtual Machine 
+        /// Adjust CPU and RAM allocation for a Virtual Machine
         /// </summary>
-        public async Task<Execution> VmEditMemory(Dictionary<string, string> parameters)
+        public async Task<Execution> VmEditMemory(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_cpu_mem_edit", parameters);
         }
@@ -267,15 +267,15 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Retrieve details of a VM object
         /// </summary>
-        public async Task<Execution> VmGetDetail(Dictionary<string, string> parameters)
+        public async Task<Execution> VmGetDetail(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_detail_get", parameters);
         }
 
         /// <summary>
-        /// Add New Hdd to Virtual Machine. You must Provide Either VM_ID or Name 
+        /// Add New Hdd to Virtual Machine. You must Provide Either VM_ID or Name
         /// </summary>
-        public async Task<Execution> VmAddHdd(Dictionary<string, string> parameters)
+        public async Task<Execution> VmAddHdd(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_hdd_add", parameters);
         }
@@ -283,15 +283,15 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Retrieve moid of a VM object
         /// </summary>
-        public async Task<Execution> VmGetMoid(Dictionary<string, string> parameters)
+        public async Task<Execution> VmGetMoid(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_moid_get", parameters);
         }
 
         /// <summary>
-        /// Add New Hdd to Virtual Machine. You must Provide Either VM_ID or Name 
+        /// Add New Hdd to Virtual Machine. You must Provide Either VM_ID or Name
         /// </summary>
-        public async Task<Execution> VmNicAdd(Dictionary<string, string> parameters)
+        public async Task<Execution> VmNicAdd(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_nic_add", parameters);
         }
@@ -299,23 +299,23 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Alter Configuration of Network Adapater
         /// </summary>
-        public async Task<Execution> VmNicEdit(Dictionary<string, string> parameters)
+        public async Task<Execution> VmNicEdit(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_nic_edit", parameters);
         }
 
         /// <summary>
-        /// Performs a Hardware Power Off of a VM. Note: This is not an OS shutdown 
+        /// Performs a Hardware Power Off of a VM. Note: This is not an OS shutdown
         /// </summary>
-        public async Task<Execution> VmPowerOff(Dictionary<string, string> parameters)
+        public async Task<Execution> VmPowerOff(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_power_off", parameters);
         }
 
         /// <summary>
-        /// Performs a Hardware Power On of a VM 
+        /// Performs a Hardware Power On of a VM
         /// </summary>
-        public async Task<Execution> VmPowerOn(Dictionary<string, string> parameters)
+        public async Task<Execution> VmPowerOn(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_power_on", parameters);
         }
@@ -323,31 +323,31 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Removes the Virtual Machine
         /// </summary>
-        public async Task<Execution> VmRemove(Dictionary<string, string> parameters)
+        public async Task<Execution> VmRemove(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_remove", parameters);
         }
 
         /// <summary>
-        /// Add SCSI Controller to VM. You must provide at least one of VM_ID or Name 
+        /// Add SCSI Controller to VM. You must provide at least one of VM_ID or Name
         /// </summary>
-        public async Task<Execution> VmScsiControllerAdd(Dictionary<string, string> parameters)
+        public async Task<Execution> VmScsiControllerAdd(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_scsi_controller_add", parameters);
         }
 
         /// <summary>
-        /// Retrieve uuid of a VM object 
+        /// Retrieve uuid of a VM object
         /// </summary>
-        public async Task<Execution> VmGetUuid(Dictionary<string, string> parameters)
+        public async Task<Execution> VmGetUuid(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_hw_uuid_get", parameters);
         }
 
         /// <summary>
-        /// Retrieve Runtime details of a VM object 
+        /// Retrieve Runtime details of a VM object
         /// </summary>
-        public async Task<Execution> VmGetRuntimeInfo(Dictionary<string, string> parameters)
+        public async Task<Execution> VmGetRuntimeInfo(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_runtime_info_get", parameters);
         }
@@ -355,7 +355,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// Initiates a clean shutdown of the guest. Returns immediately without waiting for the guest to complete shutdown
         /// </summary>
-        public async Task<Execution> VmShutdown(Dictionary<string, string> parameters)
+        public async Task<Execution> VmShutdown(Dictionary<string, object> parameters)
         {
             return await AddExecution("vsphere.vm_shutdown", parameters);
         }
@@ -363,7 +363,7 @@ namespace stackstorm.api.client.Executions
         /// <summary>
         /// TODO: Wait for a Task to complete and returns its result
         /// </summary>
-        public async Task<Execution> Wait(Dictionary<string, string> parameters)
+        public async Task<Execution> Wait(Dictionary<string, object> parameters)
         {
             throw new NotImplementedException("Not sure where task Id comes from");
             //TODO

--- a/Stackstorm.Api.Client/Models/ExecuteActionRequest.cs
+++ b/Stackstorm.Api.Client/Models/ExecuteActionRequest.cs
@@ -4,16 +4,15 @@ using System.Collections.Generic;
 
 namespace Stackstorm.Api.Client.Models
 {
- public class ExecuteActionRequest
- {
-  public string action;
-  public Dictionary<string, string> parameters;
- }
+    public class ExecuteActionRequest
+    {
+        public string action;
+        public Dictionary<string, object> parameters;
+    }
 
- public class ExecuteComplexActionRequest
- {
-  public string action;
-  public Dictionary<string, object> parameters;
- }
+    public class ExecuteComplexActionRequest
+    {
+        public string action;
+        public Dictionary<string, object> parameters;
+    }
 }
-

--- a/Stackstorm.Api.Client/Models/ExecutionRequest.cs
+++ b/Stackstorm.Api.Client/Models/ExecutionRequest.cs
@@ -6,18 +6,18 @@ namespace Stackstorm.Api.Client.Models
 {
     public class ExecutionRequest
     {
-        public Dictionary<string, string> parameters { get; private set; }
- 
+        public Dictionary<string, object> parameters { get; private set; }
+
         public string action { get; private set; }
 
         public ExecutionRequest()
         {
-            this.parameters = new Dictionary<string, string>();
+            this.parameters = new Dictionary<string, object>();
         }
 
-        public ExecutionRequest(string action, Dictionary<string, string> parameterDictionary)
+        public ExecutionRequest(string action, Dictionary<string, object> parameterDictionary)
         {
-            this.parameters = parameterDictionary ?? new Dictionary<string, string>();
+            this.parameters = parameterDictionary ?? new Dictionary<string, object>();
             this.action = action;
         }
 
@@ -36,7 +36,7 @@ namespace Stackstorm.Api.Client.Models
         public void AddParameter(string key, IEnumerable<string> values)
         {
             if (values == null) return;
-            
+
             foreach (var val in values)
             {
                 AddParameter(key, val);

--- a/Stackstorm.Api.Client/Models/RuleAction.cs
+++ b/Stackstorm.Api.Client/Models/RuleAction.cs
@@ -4,9 +4,9 @@ using System.Collections.Generic;
 
 namespace Stackstorm.Api.Client.Models
 {
- public class RuleAction
- {
-  public Dictionary<string, string> parameters { get; set; }
-  public string @ref { get; set; }
- }
+    public class RuleAction
+    {
+        public Dictionary<string, object> parameters { get; set; }
+        public string @ref { get; set; }
+    }
 }

--- a/Stackstorm.Api.Client/Models/RuleType.cs
+++ b/Stackstorm.Api.Client/Models/RuleType.cs
@@ -7,6 +7,6 @@ namespace Stackstorm.Api.Client.Models
     public class RuleType
     {
         public string @ref { get; set; }
-        public Dictionary<string, string> parameters { get; set; }
+        public Dictionary<string, object> parameters { get; set; }
     }
 }

--- a/Stackstorm.Api.Client/Models/Trigger.cs
+++ b/Stackstorm.Api.Client/Models/Trigger.cs
@@ -8,6 +8,6 @@ namespace Stackstorm.Api.Client.Models
     {
         public string type { get; set; }
         public string @ref { get; set; }
-        public Dictionary<string, string> parameters { get; set; }
+        public Dictionary<string, object> parameters { get; set; }
     }
 }

--- a/Stackstorm.Api.Client/St2Client.cs
+++ b/Stackstorm.Api.Client/St2Client.cs
@@ -79,6 +79,7 @@ namespace Stackstorm.Api.Client
             Rules = new RulesApi(this);
             VSphere = new VSphere(this);
             Core = new Core(this);
+            Email = new Email(this);
         }
 
         /// <summary> Refresh the auth token. </summary>
@@ -218,8 +219,9 @@ namespace Stackstorm.Api.Client
                 }
             }
         }
-        
+
         public IVSphere VSphere { get; private set; }
+        public IEmail Email { get; private set; }
         public ICore Core { get; private set; }
 
         /// <summary> Accessor for the Actions related methods. </summary>

--- a/Stackstorm.Connector/Connectors/Email.cs
+++ b/Stackstorm.Connector/Connectors/Email.cs
@@ -1,0 +1,47 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Stackstorm.Connector.Models.Vsphere;
+using Stackstorm.Api.Client;
+using Stackstorm.Api.Client.Extensions;
+using NLog.Fluent;
+
+namespace Stackstorm.Connector
+{
+    public class Email
+    {
+        private readonly St2Client _client;
+
+        public Email(St2Client client)
+        {
+            _client = client;
+        }
+        public async Task<Models.Email.Responses.EmailSent> SendEmail(Models.Email.Requests.EmailSend request)
+        {
+            var returnObject = new Models.Email.Responses.EmailSent();
+            var executionResult = await _client.Email.SendEmail(new Dictionary<string, object>
+                {{"account", request.Account}, {"email_from", request.EmailFrom}, {"email_to", request.EmailTo}, {"message", request.Message},
+                 {"subject", request.Subject}, {"mime", request.Mime}, {"email_cc", request.EmailCC}});
+            Log.Trace($"ExecutionResult: {executionResult}");
+
+            try
+            {
+                returnObject.Id = executionResult.id;
+                returnObject.Success = executionResult.status.ToLower() == "succeeded";
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Object was not in expected format: {e}");
+                Console.WriteLine(e);
+                returnObject.Exception = e;
+                returnObject.Success = false;
+            }
+
+            return returnObject;
+        }
+    }
+}

--- a/Stackstorm.Connector/Models/Email.cs
+++ b/Stackstorm.Connector/Models/Email.cs
@@ -1,0 +1,36 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+using System;
+using System.Collections.Generic;
+
+namespace Stackstorm.Connector.Models.Email
+{
+    public class Requests
+    {
+        public class EmailSend
+        {
+            public string Account { get; set; }
+            public string EmailFrom { get; set; }
+            public string[] EmailTo { get; set; }
+            public string Message { get; set; }
+            public string Subject { get; set; }
+            public string[] AttachmentPaths { get; set; }
+            public string[] EmailCC { get; set; }
+            public string Mime { get; set; }
+        }
+    }
+
+    public class Responses
+    {
+        public class ResponseBase
+        {
+            public string Id { get; set; }
+            public Exception Exception { get; set; }
+        }
+
+        public class EmailSent : ResponseBase
+        {
+            public bool Success { get; set; }
+        }
+    }
+}

--- a/Stackstorm.Connector/Stackstorm.Connector.csproj
+++ b/Stackstorm.Connector/Stackstorm.Connector.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-      <PackageReference Include="Stackstorm.Api.Client" />
+      <ProjectReference Include="..\Stackstorm.Api.Client\Stackstorm.Api.Client.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Stackstorm.Connector/StackstormConnector.cs
+++ b/Stackstorm.Connector/StackstormConnector.cs
@@ -1,14 +1,18 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+using Stackstorm.Api.Client;
+
 namespace Stackstorm.Connector
 {
-    public class StackstormConnector
+    public class StackstormConnector : StackstormBase
     {
         public VSphere VSphere { get; private set; }
-        
-        public StackstormConnector()
+        public Email Email { get; private set; }
+
+        public StackstormConnector(string url, string username, string password) : base(url, username, password)
         {
-            this.VSphere = new VSphere();
+            this.Email = new Email(this.Client);
+            this.VSphere = new VSphere(this.Client);
         }
     }
 }

--- a/Stackstorm.Connector/nuget.config
+++ b/Stackstorm.Connector/nuget.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="stackstorm-api-client" value="..\Stackstorm.Api.Client\artifacts" />
     <add key="default" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
- BREAKING CHANGE - refactored Vsphere to receive it's St2Client from
StackstormConnector, so consumers should now create a StackstormConnector
and use it's VSphere property instead of creating a VSphere object directly.
- added an Email object to StackstormConnector to call methods of the Email pack
- changed reference to Stackstorm.Api.Client to a project reference to simplify build